### PR TITLE
provide false for hardware accel since we know simpleoptions will be nil

### DIFF
--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -338,7 +338,7 @@ func (j *Job) addOutputArgs(args []string) []string {
 		args = append(args, "-c:a", "libopus", "-b:a", "256k")
 	} else {
 		// Default fallback if SimpleOptions is nil
-		args = append(args, strings.Fields(GetFFmpegPresetArgs(DefaultQualityPreset, j.SimpleOptions.UseHardwareAcceleration))...)
+		args = append(args, strings.Fields(GetFFmpegPresetArgs(DefaultQualityPreset, false))...)
 	}
 
 	return args

--- a/internal/model/job_test.go
+++ b/internal/model/job_test.go
@@ -416,6 +416,18 @@ func TestGetFFmpegCommand(t *testing.T) {
 		wantContains []string
 	}{
 		{
+			name: "Job with no simple options",
+			job: Job{
+				InputFilePath:  "/input.mp4",
+				OutputFilePath: "/output.mp4",
+			},
+			wantContains: []string{
+				"-y", "-hide_banner",
+				"-i", "/input.mp4",
+				"/output.mp4",
+			},
+		},
+		{
 			name: "Simple job with hardware",
 			job: Job{
 				InputFilePath:  "/input.mp4",


### PR DESCRIPTION
Currently the attempt to access `j.SimpleOptions.UseHardwareAcceleration` will always panic because we just checked that it's nil above. Instead just provide false since we don't have simpleOptions in this case.